### PR TITLE
Updated README.md to include License Badge (Issue #6)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Contributors](https://img.shields.io/github/contributors/gh-conf/gh-conf-constants.svg)](https://github.com/gh-conf/gh-conf-constants/graphs/contributors)
 [![Commit](https://img.shields.io/github/last-commit/gh-conf/gh-conf-constants.svg)](https://github.com/gh-conf/gh-conf-constants/commits/master)
 [![Github Repo Size](https://img.shields.io/github/repo-size/gh-conf/gh-conf-constants.svg)](https://github.com/gh-conf/gh-conf-constants)
+[![LICENSE](https://img.shields.io/npm/l/@gh-conf/gh-conf-constants.svg)](https://github.com/gh-conf/gh-conf-constants/LICENSE)
 
 Constants for gh-conf.
 


### PR DESCRIPTION
Updated README.md to include License Badge. Previously this badge was not included on the README.md. Now, the badge is included after Github Repo Size on line 7.  

Issue: [Issue #6](https://github.com/gh-conf/gh-conf-constants/issues/6)
Badge Code: `[![LICENSE](https://img.shields.io/npm/l/@gh-conf/gh-conf-constants.svg)](https://github.com/gh-conf/gh-conf-constants/LICENSE)`
